### PR TITLE
Update version of gofrolist/molecule-action to v2

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           path: "${{ github.repository }}"
           fetch-depth: 0
-      - uses: gofrolist/molecule-action@v2.0.2
+      - uses: gofrolist/molecule-action@v2
         with:
           molecule_command: test
           molecule_args: --scenario-name ${{ matrix.scenario }}


### PR DESCRIPTION
gofrolist/molecule-action is updated recently and here is [Release notes](https://github.com/gofrolist/molecule-action/releases)
Also I [recommend ](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#recommendations) to use "v2" tag unless you have an issue with new versions or you can use dependabot to track updates of actions you are using.